### PR TITLE
Add ApplaudeExplainer skill

### DIFF
--- a/.agents/skills/ApplaudeExplainer/References/content-patterns.md
+++ b/.agents/skills/ApplaudeExplainer/References/content-patterns.md
@@ -1,0 +1,63 @@
+# Content Patterns — Writing Voice
+
+The Applaudé look carries the design; this carries the words. Editorial, specific, short. Italic for tone, bold for facts.
+
+## Hero lede formula (three sentences)
+
+1. **The lazy story** — what people assume the topic is. *"The README sells Hokage as '5 verb skills, zero config'."*
+2. **The real story** — what it actually is, with the pivot word in italics. *"The **real** Hokage is 129 shell scripts and 27 hooks that claim almost every lifecycle event."*
+3. **The call to read** — what the page delivers. *"Six chapters: what it is, the loop, the hook surface, the safety teardown."*
+
+Italicise the pivot word ("real", "actual", "quietly"). Bold the load-bearing facts.
+
+## Chapter formula
+
+Each chapter is one idea:
+1. **`.chapter-num`** — "Chapter I" in italic clay.
+2. **`.chapter-h`** — a phrase, not a sentence. Display serif. Wrap the secondary clause in `.muted` (italic, quiet).
+3. **`.chapter-p`** — 2–4 sentences. State the fact, state the number, quote the ID. Then a component (flow grid / yaml card / ledger / table) that *shows* it.
+4. **`.h-sub`** between sub-sections when a chapter has two beats.
+
+## The "named numbers" rule
+
+A page lives or dies on its numbers. **≥4 named, specific, source-cited numbers per chapter**, surfaced in the stat strip and inline.
+
+- Bad: *"dramatically faster hooks."* Good: *"hooks fire in under 10ms vs v3's 40–60ms of Node overhead."*
+- Bad: *"a huge plugin."* Good: *"33 skills, 4 agents, 27 hooks, ~2,411 always-on tokens."*
+
+The 2nd and 3rd stat-strip numbers render italic clay — put your two most striking numbers there.
+
+## The verbatim-ID rule
+
+Every model ID, repo path, SKU, version, env var, command, or config key goes in a `<code>` chip, verbatim. It's the anchor a reader uses to verify and the string they'll paste into a terminal: `claude-code-harness@claude-code-harness-marketplace`, `HARNESS_MEM_HOST`, `permissionDecision: "deny"`, `CLAUDE_CONFIG_DIR`.
+
+## The "what / when / why" card structure
+
+For feature-by-feature breakdowns (ledger rows or grid cards):
+- **What it is** → the tag / badge.
+- **Title** → the `.ledger-t` / `h3`.
+- **What it does** → the body.
+- **What it costs you** → an optional stat.
+- **Where to read more** → a source link.
+
+## The bombshell
+
+Find the one buried, non-obvious finding — the thing that reframes the topic — and give it the single dark `.callout`. One per page. It's the line a reader screenshots.
+
+## The cheat sheet
+
+Readers want the decision. End the analysis chapters with a `.tbl` decision matrix: *if you want X → do Y → why.* Three to five rows.
+
+## Tone
+
+- **Confident, not hedged.** "It does X," not "it seems to do X."
+- **Editorial, not corporate.** "It *quietly* ships" not "it offers a comprehensive suite."
+- **Specific over general.** Names, numbers, dates, exact quotes.
+- **Short over long.** Cut every sentence in half until it stops cutting.
+- **Italic = tone (clay, human). Bold = fact (ink). Mono = system speaking.** Don't mix.
+
+Read every paragraph back. If a sentence adds neither a fact nor sharper framing, cut it.
+
+## Honest mode (no hype)
+
+When the brief is "explain it straight" — *is it good, how is it different, what's the catch* — answer the question in the reader's mind without sloganeering. State the real tradeoff. Name what it's bad at. A teardown earns trust precisely because it isn't selling. Sage = genuinely good, clay = the human caveat, never a fake superlative.

--- a/.agents/skills/ApplaudeExplainer/References/design-system.md
+++ b/.agents/skills/ApplaudeExplainer/References/design-system.md
@@ -1,0 +1,74 @@
+# Applaudé — Design System (for the explainer skill)
+
+*"Apple × Claude editorial language."* Warm paper, warm ink, clay-italic accents, hairlines, big whitespace. The exact CSS lives in `template.html` — **keep that `<style>` block verbatim**. This file explains *what each token and component means* so you fill content into the right place.
+
+## 1. Palette — "Claude warm neutral + clay"
+
+| Token | Hex | Role |
+|---|---|---|
+| `--pampas` | `#F0EEE6` | Warm off-white **canvas** (page bg) |
+| `--pampas-deep` | `#E8E5DA` | Alt sections — alternate chapters with `.chapter-flip` |
+| `--bone` | `#FAF9F5` | Lightest neutral — cards, code blocks |
+| `--ink` | `#1F1E1D` | Warm near-black — primary text, primary button, the one dark callout |
+| `--ink-soft` `--ink-quiet` `--ink-whisper` | `#3D3D3A` `#6B6A65` `#A09E96` | Secondary / tertiary / caption text |
+| `--crail` | `#C96442` | **Signature Claude clay** — accent, italic words, link hover, live dot, CTA hover |
+| `--crail-deep` `--crail-tint` | `#A84F31` `#E8B89F` | Clay hover; soft clay for accents on dark surfaces |
+| `--leaf` | `#8B9D7E` | Sage — "approved / synced / verified" state only |
+| `--sky` | `#6B8AA8` | Cool — numbers / value types only, used sparingly |
+
+Window-chrome dots (code cards): red `#E66B5C`, yellow `#E5C76B`, green `#8DBE7A`.
+
+## 2. Type
+
+- `--font-display` / `--font-body` → `'Tiempos Headline'/'Tiempos Text'` (if licensed) then **`Fraunces`** serif. Hero, chapter heads, stats, long-form prose.
+- `--font-ui` / `--font-sans` → **`Geist`**. Buttons, eyebrows, labels, nav, table headers.
+- `--font-mono` → **`Geist Mono`**. Code, YAML, file names, timestamps, micro-meta, sync lines.
+
+Letter-spacing: **negative on display** (`-0.045em` hero, `-0.025em` chapter heads), **positive on uppercase UI** (`+0.16em` eyebrows, `+0.04em` mono meta). `text-wrap: balance` on heads.
+
+Type scale: `--t-mega 168 / --t-hero 104 / --t-display 64 / --t-h1 48 / --t-h2 32 / --t-h3 20 / body 18 / small 15 / caption 13 / micro 11` (all responsive `clamp`).
+
+## 3. Voice & rules (memorize these — they ARE the look)
+
+1. **Editorial, not productized.** Centered columns 640–880px, heavy whitespace, italic clay emphasis (`em { color: crail; font-style: italic }`).
+2. **Hairlines, not borders.** Every divider `0.5px @ 8–18% ink`. Never solid 1px.
+3. **Mono = "system speaking."** YAML, filenames, timestamps, eyebrow micro-meta.
+4. **Italic serif = "voice / human."** Hero accent word, chapter numerals, captions.
+5. **Clay is a verb, not a fill.** It punctuates — hero accent word, em, link hover, live dot, CTA hover, and the single dark callout's accent. It never floods areas.
+6. **Two-tone temperature.** Warm pampas/bone + warm ink + clay. Sage and sky are *condiments* — state and numbers only.
+7. **Generous breathing.** Chapters `120–140px` padding; hero full-viewport.
+8. **Soft warm shadows.** Tinted with ink, large/soft (`--shadow-soft/lift/deep`), editorial not material.
+
+One-liner: *Pampas canvas + warm ink + clay-italic accents. Hairlines not borders. Mono for system, italic serif for voice. Big whitespace. Sage = good, sky = number, clay = human.*
+
+## 4. Components (class → when to use → content)
+
+| Component | Class | Use it for |
+|---|---|---|
+| **Nav** | `.app-nav` | Fixed glass bar. Mark in display-serif (`<word> <em>teardown/guide</em>`), section links as pills, right meta in mono (version · license). |
+| **Hero** | `.hero` | Full-viewport. `.hero-eyebrow` pill with pulsing `.hero-dot`, serif `h1` with **one** `<em>` clay-italic accent word, `.hero-lede` (3-sentence lazy→real→read), `.hero-cta` button pair, `.lede-note` mono provenance line. |
+| **Stat strip** | `.stats > .stat` | The 4 headline numbers. `.stat-n` display; 2nd & 3rd auto-render italic clay. `.stat-l` mono-ish label. Use `<span class="u">` for units (k, M, %). |
+| **Chapter** | `.chapter` / `.chapter chapter-flip` | The narrative. `.chapter-num` (italic clay "Chapter I"), `.chapter-h` (display head; wrap secondary clause in `.muted`), `.chapter-p` body. `.h-sub` = mono uppercase sub-section header with trailing hairline. Alternate flip bg. |
+| **Flow grid** | `.flow-grid > .flow-step / .flow-arrow` | Any sequence/loop/pipeline. 3–4 steps + `→` arrows. Each step: `.flow-num` (mono), `.flow-title` (display), `.flow-sub` (mono clay), `.flow-body`. Collapses to 1 column on mobile, arrows rotate. |
+| **YAML/code card** | `.yaml-card` | Commands, config, code. `.yaml-head` with 3 traffic-light `.dot`s + mono `.yaml-file` name. `.yaml-body` lines as `<span class="l">`; token classes `.k` (keys=clay) `.s` (strings=sage) `.n` (numbers=sky) `.c` (comments) `.d` (dim). |
+| **Note card** | `.note-card` | A verified / synced state. `.note-circle` (clay ring), mono `.note-title`, mono `.note-body`, `.note-sync` row with `.sync-dot` (sage = good). |
+| **Dark callout** | `.callout > .callout-inner` | The ONE bombshell finding. Dark ink card, `.callout-eye` clay-tint eyebrow, `.callout-h` with `<em>` crail-tint accents, `.callout-p`. |
+| **Decision matrix** | `.tbl-wrap > table.tbl` | The "if you want X → do Y → why" cheat sheet. `.pick` (the choice) + `.why`. |
+| **Ledger** | `.ledger > .ledger-row` | Numbered findings list. `.ledger-i` (clay numeral or ✓ in sage), `.ledger-t` (display), `.ledger-b` (body). Use `.tag-good`/`.tag-warn` mono tags. |
+| **Closing** | `.closing` | `.closing-mark` (clay glyph ✦), `.closing-h`, `.closing-p`, `.closing-cta` button pair. |
+| **Footer** | `footer` | `.foot-gift` (display line w/ italic clay em), `.foot-meta` mono column, `.sources` block with every URL (`↗` prefixed mono links). |
+
+## 5. Motion
+
+- Reveal-on-scroll: `.reveal` → `.in`, `opacity + translateY(24→0)` over `1.2s cubic-bezier(.2,.7,.2,1)`, IntersectionObserver `threshold 0.08`. Add `.reveal` to every section/inner.
+- Live dot: `pulse 2.4s` clay ring. Sync dot: static sage with soft ring. Button hover: `translateY(-1px) + shadow-lift`, bg → clay on primary.
+- Nav active: highlight the link for the section in view (script at bottom of template).
+
+## 6. Responsive
+
+- `≤880px`: flow grid → 1 column, arrows rotate 90°; stats → 2-up.
+- `≤760px`: nav links hide; tighter paddings.
+
+## 7. Drop-in token block
+
+The full `:root` token block is the first thing in `template.html`'s `<style>`. Copy the template; don't re-derive it.

--- a/.agents/skills/ApplaudeExplainer/References/sixteen-word.md
+++ b/.agents/skills/ApplaudeExplainer/References/sixteen-word.md
@@ -1,0 +1,49 @@
+# `#16w` Mode — Drop a Repo, Answer the 10 Questions (No Sales Shit)
+
+Trigger: **`#16w`** + a GitHub URL (or repo path). Produces an Applaudé explainer whose structure *answers* the 10 questions of the 16-word sales-letter framework — **without ever stating the question, and without a word of hype.** A teardown earns belief precisely because it isn't selling.
+
+## Intake (do this first)
+
+1. **Clone shallow to `/tmp`** and read for real — README, `package.json`/`go.mod`/`Cargo.toml`, `LICENSE`, `/docs`, the actual entry-point source, and `hooks`/config if present. Don't explain from the README alone.
+2. **Capture hard facts**: stars, last-commit date, open issues, test count, license, language, dependency count, version, benchmark numbers, install command.
+3. **Trace anything that runs on the user's machine** (binaries, hooks, postinstall scripts, network calls). Honesty about risk is the trust currency.
+4. Keep every URL for the sources block.
+
+## The 10 answers → where they live on the page
+
+Answer each in the reader's mind. **Never print the question.** Deliver the answer as fact.
+
+| # | Question (never shown) | How to answer it, honestly | Applaudé component |
+|---|---|---|---|
+| 1 | How is this different? | The one structural thing it does that nothing else does. State the delta, not "revolutionary". | Hero accent line + a `vs` decision matrix |
+| 2 | What's in it for me? | The concrete outcome, as a fact: *"hooks fire in <10ms"* not *"blazing fast"*. | Hero lede real-story + stat strip |
+| 3 | How do I know it's real? | Proof from the repo — stars, tests passing, benchmark numbers, real commit cadence. | Stat strip + `note-card` (verified) + ledger with `tag-good` |
+| 4 | What's holding me back? | The genuine friction it removes — name the real pain, specifically. | A "the friction" chapter |
+| 5 | Who/what's to blame? | The honest limitation of the *current* approach it replaces — the old way, not a strawman enemy. | "the old way" chapter (`.chapter-flip`) |
+| 6 | Why now? | What changed that makes it possible/worthwhile today (a model, a primitive, a cost curve). | A short "why now" chapter |
+| 7 | Why trust it? | Provenance: author, license, maintenance, and the **safety/egress teardown**. Show the receipts. | `note-card` + the egress ledger (sage = clean) |
+| 8 | How does it work? | The mechanism, plainly. | `flow-grid` (the pipeline) + `yaml-card` (real config) |
+| 9 | How to start? | The exact commands. No friction, no upsell. | `yaml-card` with verbatim install lines |
+| 10 | What do I have to lose? | The real cons + how reversible it is (uninstall, sandbox, cost). Name what it's bad at. | Final ledger with `tag-warn` + `tbl` cheat sheet |
+
+The single dark `.callout` carries the **most honest** line on the page — the buried tradeoff or the genuine "this is the catch." That candor is what makes the rest believed.
+
+## No-sales-shit rules
+
+- **No superlatives without a number.** "fast" → a latency. "powerful" → a capability + its cost.
+- **State the cons.** Every honest teardown names what the thing is bad at. Question 10 is not a formality.
+- **Sage = genuinely good, clay = the human caveat.** Never paint a green where a tradeoff exists.
+- **Answer, don't ask.** The reader should finish each section with the answer settled — never having been asked.
+- Verdict over verdict-shaped marketing: end with *who should and shouldn't use it*, not a CTA to "get started now".
+
+## The 10 videos (one per answer)
+
+`#16w` can also emit a **10-part video pack** — one short per question, each landing that single answer, the question never spoken. Each script is a tight beat:
+
+1. **Cold-open hook** (2–4s) — a concrete image or number, not a claim.
+2. **The answer** (the body) — deliver the clarity for that question as lived fact / demo.
+3. **The land** (1 line) — the takeaway the viewer now believes.
+
+Script spec per video: `~20–45s`, plain spoken VO, on-screen `<code>`/number callouts, no question text, no hype words. Output as a numbered script pack (`01-different.md` … `10-what-to-lose.md`) with: hook · VO · on-screen text · b-roll/demo note · the one number it must show.
+
+**Render path is a separate choice** — the scripts are tool-agnostic. Options: `Remotion` (code-driven, on-brand Applaudé motion), `video-use` (edit existing footage), or an avatar/TTS tool. Confirm tool + aspect ratio (vertical 9:16 for shorts vs 16:9) before rendering; default to a script pack first.

--- a/.agents/skills/ApplaudeExplainer/References/template.html
+++ b/.agents/skills/ApplaudeExplainer/References/template.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<!--
+  APPLAUDÉ EXPLAINER TEMPLATE  ·  copy this file, keep the entire <style> block, refill the <body>.
+  Save the result to:  $HOME/Desktop/Explainers/{topic-slug}-explainer.html
+  {{MUSTACHE}} markers = swap for your content.  <!-- COMPONENT: ... --> = pick the ones the topic needs.
+  Repeat chapters/cards as needed. Alternate .chapter and .chapter.chapter-flip for rhythm.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{TITLE}}</title>
+<meta name="description" content="{{META_DESCRIPTION}}">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+:root{
+  /* palette — Claude warm neutral + clay */
+  --pampas:#F0EEE6; --pampas-deep:#E8E5DA; --pampas-shadow:#D9D5C7; --bone:#FAF9F5;
+  --ink:#1F1E1D; --ink-soft:#3D3D3A; --ink-quiet:#6B6A65; --ink-whisper:#A09E96;
+  --crail:#C96442; --crail-deep:#A84F31; --crail-tint:#E8B89F;
+  --leaf:#8B9D7E; --sky:#6B8AA8;
+
+  /* type — licensed faces first, Google cousins as fallback */
+  --font-display:'Tiempos Headline','Fraunces','Times New Roman',Georgia,serif;
+  --font-body:'Tiempos Text','Fraunces',Georgia,serif;
+  --font-sans:'Styrene B','Styrene B LC','Geist','Helvetica Neue',Helvetica,Arial,sans-serif;
+  --font-ui:'Geist','Helvetica Neue',system-ui,sans-serif;
+  --font-mono:'Geist Mono','SF Mono',Menlo,Consolas,monospace;
+
+  /* scale */
+  --t-mega:clamp(64px,11vw,168px); --t-hero:clamp(48px,7vw,104px);
+  --t-display:clamp(36px,4.5vw,64px); --t-h1:clamp(32px,3.6vw,48px);
+  --t-h2:clamp(24px,2.4vw,32px); --t-h3:20px;
+  --t-body:18px; --t-small:15px; --t-caption:13px; --t-micro:11px;
+
+  /* radii & shadow */
+  --r-sm:6px; --r-md:12px; --r-lg:20px; --r-xl:32px; --r-pill:999px;
+  --shadow-soft:0 2px 18px rgba(31,30,29,.06),0 1px 3px rgba(31,30,29,.04);
+  --shadow-lift:0 12px 40px rgba(31,30,29,.08),0 2px 8px rgba(31,30,29,.04);
+  --shadow-deep:0 30px 80px rgba(31,30,29,.12),0 8px 24px rgba(31,30,29,.06);
+}
+
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--pampas); color:var(--ink);
+  font-family:var(--font-body); font-size:var(--t-body); line-height:1.55;
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  font-feature-settings:"kern","liga","calt";
+  overflow-x:hidden;
+}
+::selection{background:var(--crail); color:var(--bone)}
+em{color:var(--crail); font-style:italic}
+code{
+  font-family:var(--font-mono); font-size:.86em;
+  background:var(--bone); border:.5px solid rgba(31,30,29,.12);
+  padding:.12em .42em; border-radius:var(--r-sm); color:var(--ink-soft);
+  white-space:nowrap;
+}
+a{color:inherit}
+
+/* grain */
+.grain::before{
+  content:""; position:absolute; inset:0; pointer-events:none; mix-blend-mode:multiply;
+  opacity:.6; background-image:radial-gradient(rgba(31,30,29,.18) .5px, transparent .5px);
+  background-size:3px 3px;
+}
+
+/* nav */
+.app-nav{
+  position:fixed; top:0; left:0; right:0; z-index:100;
+  display:flex; align-items:center; justify-content:space-between;
+  padding:16px 32px;
+  background:rgba(240,238,230,.78); backdrop-filter:saturate(180%) blur(20px);
+  border-bottom:.5px solid rgba(31,30,29,.10);
+}
+.nav-mark{font-family:var(--font-display); font-size:21px; letter-spacing:-.01em}
+.nav-mark em{font-style:italic}
+.nav-links{display:flex; gap:4px; align-items:center}
+.nav-links a{
+  font-family:var(--font-ui); font-size:13px; text-decoration:none; color:var(--ink-soft);
+  padding:8px 14px; border-radius:var(--r-pill); transition:background .2s, color .2s;
+}
+.nav-links a:hover{background:rgba(31,30,29,.05); color:var(--ink)}
+.nav-meta{font-family:var(--font-mono); font-size:11px; letter-spacing:.04em; color:var(--ink-quiet)}
+@media(max-width:760px){ .nav-links{display:none} }
+
+/* hero */
+.hero{
+  position:relative; min-height:100vh; display:flex; flex-direction:column;
+  align-items:center; justify-content:center; text-align:center;
+  padding:120px 32px 80px; gap:30px;
+}
+.hero-eyebrow{
+  display:inline-flex; align-items:center; gap:9px;
+  font-family:var(--font-ui); font-size:11px; letter-spacing:.16em; text-transform:uppercase;
+  color:var(--ink-quiet);
+  background:rgba(250,249,245,.7); backdrop-filter:blur(10px);
+  border:.5px solid rgba(31,30,29,.14); border-radius:var(--r-pill);
+  padding:9px 16px;
+}
+.hero-dot{
+  width:6px; height:6px; border-radius:50%; background:var(--crail);
+  box-shadow:0 0 0 0 rgba(201,100,66,.5); animation:pulse 2.4s infinite;
+}
+@keyframes pulse{
+  0%{box-shadow:0 0 0 0 rgba(201,100,66,.45)}
+  70%{box-shadow:0 0 0 8px rgba(201,100,66,0)}
+  100%{box-shadow:0 0 0 0 rgba(201,100,66,0)}
+}
+.hero h1{
+  font-family:var(--font-display); font-weight:400;
+  font-size:var(--t-hero); line-height:1.0; letter-spacing:-.045em;
+  max-width:14ch; text-wrap:balance;
+}
+.hero h1 em{font-style:italic}
+.hero-lede{
+  font-family:var(--font-body); font-size:21px; line-height:1.55; color:var(--ink-soft);
+  max-width:640px;
+}
+.hero-lede strong{color:var(--ink); font-weight:600}
+.hero-cta{display:flex; gap:12px; flex-wrap:wrap; justify-content:center; margin-top:6px}
+
+/* buttons */
+.btn{
+  font-family:var(--font-ui); font-size:14px; font-weight:500; letter-spacing:-.005em;
+  text-decoration:none; padding:12px 22px; border-radius:var(--r-pill);
+  display:inline-flex; align-items:center; gap:8px; transition:all .18s cubic-bezier(.2,.7,.2,1);
+  cursor:pointer; border:none;
+}
+.btn-primary{background:var(--ink); color:var(--bone)}
+.btn-primary:hover{background:var(--crail); transform:translateY(-1px); box-shadow:var(--shadow-lift)}
+.btn-ghost{background:transparent; color:var(--ink); border:.5px solid rgba(31,30,29,.18)}
+.btn-ghost:hover{background:rgba(31,30,29,.04)}
+
+/* stats strip */
+.stats{
+  max-width:1100px; margin:0 auto; padding:0 32px;
+  display:grid; grid-template-columns:repeat(4,1fr);
+  border-top:.5px solid rgba(31,30,29,.14); border-bottom:.5px solid rgba(31,30,29,.14);
+}
+.stat{padding:44px 22px; text-align:center; border-right:.5px solid rgba(31,30,29,.10)}
+.stat:last-child{border-right:none}
+.stat-n{font-family:var(--font-display); font-size:clamp(40px,5vw,60px); line-height:1; letter-spacing:-.03em}
+.stat:nth-child(2) .stat-n, .stat:nth-child(3) .stat-n{font-style:italic; color:var(--crail)}
+.stat-n .u{font-size:.5em; color:var(--ink-quiet); font-style:normal; letter-spacing:0}
+.stat-l{font-family:var(--font-ui); font-size:12px; text-transform:uppercase; letter-spacing:.04em; color:var(--ink-quiet); margin-top:12px}
+@media(max-width:760px){
+  .stats{grid-template-columns:repeat(2,1fr)}
+  .stat:nth-child(2){border-right:none}
+  .stat:nth-child(1),.stat:nth-child(2){border-bottom:.5px solid rgba(31,30,29,.10)}
+}
+
+/* chapters */
+.chapter{padding:130px 32px; position:relative}
+.chapter-flip{background:var(--pampas-deep)}
+.chapter-inner{max-width:880px; margin:0 auto}
+.chapter-num{font-family:var(--font-display); font-style:italic; font-size:22px; color:var(--crail); margin-bottom:18px}
+.chapter-h{
+  font-family:var(--font-display); font-weight:400; font-size:var(--t-display);
+  line-height:1.08; letter-spacing:-.025em; text-wrap:balance; max-width:18ch;
+}
+.chapter-h .muted{font-style:italic; color:var(--ink-quiet)}
+.chapter-p{font-family:var(--font-body); font-size:19px; line-height:1.62; color:var(--ink-soft); max-width:640px; margin-top:26px}
+.chapter-p + .chapter-p{margin-top:20px}
+.chapter-p strong{color:var(--ink); font-weight:600}
+.h-sub{
+  font-family:var(--font-ui); font-size:11px; letter-spacing:.16em; text-transform:uppercase;
+  color:var(--ink-quiet); margin:54px 0 22px; display:flex; align-items:center; gap:12px;
+}
+.h-sub::after{content:""; flex:1; height:.5px; background:rgba(31,30,29,.14)}
+
+/* flow diagram */
+.flow-grid{
+  display:grid; grid-template-columns:1fr auto 1fr auto 1fr auto 1fr; gap:0;
+  align-items:stretch; margin-top:44px;
+}
+.flow-step{
+  background:var(--bone); border-radius:var(--r-lg); border:.5px solid rgba(31,30,29,.12);
+  box-shadow:var(--shadow-soft); padding:28px 22px; min-height:220px;
+  display:flex; flex-direction:column;
+}
+.flow-num{font-family:var(--font-mono); font-size:11px; letter-spacing:.1em; color:var(--ink-whisper)}
+.flow-title{font-family:var(--font-display); font-size:26px; letter-spacing:-.02em; margin-top:12px}
+.flow-sub{font-family:var(--font-mono); font-size:12px; color:var(--crail); margin-top:6px}
+.flow-body{font-family:var(--font-body); font-size:14.5px; line-height:1.5; color:var(--ink-soft); margin-top:auto; padding-top:18px}
+.flow-arrow{display:flex; align-items:center; justify-content:center; color:var(--ink-whisper); font-size:20px; padding:0 6px}
+@media(max-width:880px){
+  .flow-grid{grid-template-columns:1fr}
+  .flow-arrow{transform:rotate(90deg); padding:14px 0}
+  .flow-step{min-height:0}
+}
+
+/* yaml / code window */
+.yaml-card{
+  background:var(--bone); border-radius:var(--r-md); border:.5px solid rgba(31,30,29,.14);
+  box-shadow:var(--shadow-lift); overflow:hidden; margin-top:34px;
+}
+.yaml-head{
+  display:flex; align-items:center; gap:8px; padding:11px 16px;
+  background:var(--pampas); border-bottom:.5px solid rgba(31,30,29,.10);
+}
+.dot{width:10px; height:10px; border-radius:50%}
+.dot.r{background:#E66B5C} .dot.y{background:#E5C76B} .dot.g{background:#8DBE7A}
+.yaml-file{font-family:var(--font-mono); font-size:12px; color:var(--ink-quiet); margin-left:8px}
+.yaml-body{padding:20px 22px; font-family:var(--font-mono); font-size:13px; line-height:1.75; overflow-x:auto}
+.yaml-body .l{display:block; white-space:pre}
+.k{color:var(--crail)} .s{color:var(--leaf)} .n{color:var(--sky)} .c{color:var(--ink-whisper); font-style:italic} .d{color:var(--ink-quiet)}
+
+/* note card (verified state) */
+.note-card{
+  background:var(--bone); border-radius:var(--r-lg); border:.5px solid rgba(31,30,29,.12);
+  box-shadow:var(--shadow-deep); padding:26px 28px; margin-top:34px; max-width:560px;
+}
+.note-head{display:flex; align-items:center; gap:12px}
+.note-circle{width:18px; height:18px; border-radius:50%; border:1.5px solid var(--crail); flex:none}
+.note-title{font-family:var(--font-mono); font-size:12px; color:var(--ink-soft); letter-spacing:.02em}
+.note-body{font-family:var(--font-mono); font-size:11.5px; line-height:1.8; color:var(--ink-quiet); margin-top:16px}
+.note-body b{color:var(--ink-soft); font-weight:500}
+.note-sync{display:flex; align-items:center; gap:9px; margin-top:18px; padding-top:16px; border-top:.5px solid rgba(31,30,29,.10); font-family:var(--font-mono); font-size:11px; letter-spacing:.04em; color:var(--ink-quiet)}
+.sync-dot{width:6px; height:6px; border-radius:50%; background:var(--leaf); box-shadow:0 0 0 3px rgba(139,157,126,.18)}
+
+/* clay callout (the bombshell) */
+.callout{max-width:880px; margin:0 auto; padding:0 32px}
+.callout-inner{
+  background:var(--ink); color:var(--bone); border-radius:var(--r-xl);
+  padding:54px 48px; position:relative; overflow:hidden; box-shadow:var(--shadow-deep);
+}
+.callout-eye{font-family:var(--font-ui); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--crail-tint)}
+.callout-h{font-family:var(--font-display); font-size:clamp(28px,3.6vw,44px); line-height:1.12; letter-spacing:-.02em; margin-top:18px; text-wrap:balance}
+.callout-h em{color:var(--crail-tint)}
+.callout-p{font-family:var(--font-body); font-size:17px; line-height:1.6; color:rgba(250,249,245,.72); margin-top:20px; max-width:600px}
+
+/* decision matrix */
+.tbl-wrap{margin-top:38px; overflow-x:auto; border-radius:var(--r-md); border:.5px solid rgba(31,30,29,.12); box-shadow:var(--shadow-soft)}
+table.tbl{width:100%; border-collapse:collapse; background:var(--bone); min-width:560px}
+.tbl th{
+  font-family:var(--font-ui); font-size:11px; text-transform:uppercase; letter-spacing:.1em;
+  color:var(--ink-quiet); text-align:left; padding:16px 20px; border-bottom:.5px solid rgba(31,30,29,.14); font-weight:500;
+}
+.tbl td{padding:18px 20px; border-bottom:.5px solid rgba(31,30,29,.08); vertical-align:top; font-family:var(--font-body); font-size:15px; color:var(--ink-soft)}
+.tbl tr:last-child td{border-bottom:none}
+.pick{font-family:var(--font-ui); font-weight:500; color:var(--ink); font-size:14px}
+.why{font-family:var(--font-body); font-size:14.5px; color:var(--ink-quiet); line-height:1.5}
+
+/* ledger rows */
+.ledger{margin-top:36px; border-top:.5px solid rgba(31,30,29,.14)}
+.ledger-row{display:grid; grid-template-columns:34px 1fr; gap:18px; padding:22px 4px; border-bottom:.5px solid rgba(31,30,29,.10); align-items:start}
+.ledger-i{font-family:var(--font-mono); font-size:13px; color:var(--crail); padding-top:2px}
+.ledger-t{font-family:var(--font-display); font-size:20px; letter-spacing:-.01em}
+.ledger-b{font-family:var(--font-body); font-size:15px; color:var(--ink-soft); line-height:1.55; margin-top:6px}
+.tag-good{color:var(--leaf); font-family:var(--font-mono); font-size:11px; letter-spacing:.06em; text-transform:uppercase}
+.tag-warn{color:var(--crail); font-family:var(--font-mono); font-size:11px; letter-spacing:.06em; text-transform:uppercase}
+
+/* closing */
+.closing{padding:140px 32px; text-align:center}
+.closing-mark{font-family:var(--font-display); font-style:italic; font-size:72px; color:var(--crail); line-height:1}
+.closing-h{font-family:var(--font-display); font-size:var(--t-display); letter-spacing:-.025em; line-height:1.1; margin-top:24px; text-wrap:balance; max-width:16ch; margin-left:auto; margin-right:auto}
+.closing-p{font-family:var(--font-body); font-size:19px; color:var(--ink-soft); max-width:560px; margin:24px auto 0}
+.closing-cta{display:flex; gap:12px; justify-content:center; flex-wrap:wrap; margin-top:36px}
+
+/* footer */
+footer{border-top:.5px solid rgba(31,30,29,.14); padding:56px 32px; background:var(--pampas-deep)}
+.foot-inner{max-width:1100px; margin:0 auto; display:flex; justify-content:space-between; gap:40px; flex-wrap:wrap}
+.foot-gift{font-family:var(--font-display); font-size:20px; max-width:30ch; line-height:1.3}
+.foot-gift em{font-style:italic}
+.foot-meta{font-family:var(--font-mono); font-size:11px; letter-spacing:.04em; color:var(--ink-quiet); line-height:2}
+.sources{max-width:1100px; margin:40px auto 0; padding-top:28px; border-top:.5px solid rgba(31,30,29,.10)}
+.sources-h{font-family:var(--font-ui); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--ink-quiet); margin-bottom:16px}
+.sources a{display:block; font-family:var(--font-mono); font-size:12.5px; color:var(--ink-soft); text-decoration:none; padding:7px 0; border-bottom:.5px solid rgba(31,30,29,.06); transition:color .2s}
+.sources a:hover{color:var(--crail)}
+.sources a::before{content:"↗ "; color:var(--ink-whisper)}
+
+/* reveal */
+.reveal{opacity:0; transform:translateY(24px); transition:opacity 1.2s cubic-bezier(.2,.7,.2,1), transform 1.2s cubic-bezier(.2,.7,.2,1)}
+.reveal.in{opacity:1; transform:none}
+.lede-note{font-family:var(--font-mono); font-size:12px; color:var(--ink-whisper); letter-spacing:.03em; margin-top:14px}
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav class="app-nav">
+  <div class="nav-mark">{{MARK}} <em>{{MARK_KIND}}</em></div>
+  <div class="nav-links">
+    <a href="#c1">{{NAV_1}}</a>
+    <a href="#c2">{{NAV_2}}</a>
+    <a href="#c3">{{NAV_3}}</a>
+    <a href="#c4">{{NAV_4}}</a>
+  </div>
+  <div class="nav-meta">{{NAV_META}}</div>
+</nav>
+
+<!-- HERO  (eyebrow pill · serif h1 with ONE clay-italic accent · 3-sentence lede · CTA pair) -->
+<header class="hero grain">
+  <span class="hero-eyebrow"><span class="hero-dot"></span> {{EYEBROW}}</span>
+  <h1>{{HEAD_A}} <em>{{ACCENT_WORD}}</em> {{HEAD_B}}</h1>
+  <p class="hero-lede">{{LAZY_STORY}} The <strong>real</strong> story: {{REAL_STORY}}. {{CALL_TO_READ}}</p>
+  <div class="hero-cta">
+    <a class="btn btn-primary" href="#c1">{{CTA_PRIMARY}} ↓</a>
+    <a class="btn btn-ghost" href="{{SOURCE_URL}}" target="_blank" rel="noopener">{{CTA_GHOST}} ↗</a>
+  </div>
+  <p class="lede-note">{{PROVENANCE_LINE}}</p>
+</header>
+
+<!-- STATS  (4 headline numbers; 2nd & 3rd auto-render italic clay) -->
+<section class="stats reveal">
+  <div class="stat"><div class="stat-n">{{N1}}</div><div class="stat-l">{{L1}}</div></div>
+  <div class="stat"><div class="stat-n">{{N2}}</div><div class="stat-l">{{L2}}</div></div>
+  <div class="stat"><div class="stat-n">{{N3}}</div><div class="stat-l">{{L3}}</div></div>
+  <div class="stat"><div class="stat-n">{{N4}}<span class="u">{{U4}}</span></div><div class="stat-l">{{L4}}</div></div>
+</section>
+
+<!-- CHAPTER  (repeat; alternate plain / .chapter-flip). Drop in the components the chapter needs. -->
+<section class="chapter" id="c1">
+  <div class="chapter-inner reveal">
+    <div class="chapter-num">Chapter I</div>
+    <h2 class="chapter-h">{{CHAPTER_HEAD}} <span class="muted">{{MUTED_CLAUSE}}</span></h2>
+    <p class="chapter-p">{{BODY}} Quote IDs as <code>{{ID}}</code> and numbers like <strong>{{NUMBER}}</strong>.</p>
+
+    <!-- COMPONENT: flow grid (sequence / loop / pipeline) -->
+    <div class="flow-grid">
+      <div class="flow-step"><div class="flow-num">01</div><div class="flow-title">{{STEP1}}</div><div class="flow-sub">{{SUB1}}</div><div class="flow-body">{{BODY1}}</div></div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step"><div class="flow-num">02</div><div class="flow-title">{{STEP2}}</div><div class="flow-sub">{{SUB2}}</div><div class="flow-body">{{BODY2}}</div></div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step"><div class="flow-num">03</div><div class="flow-title">{{STEP3}}</div><div class="flow-sub">{{SUB3}}</div><div class="flow-body">{{BODY3}}</div></div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-step"><div class="flow-num">04</div><div class="flow-title">{{STEP4}}</div><div class="flow-sub">{{SUB4}}</div><div class="flow-body">{{BODY4}}</div></div>
+    </div>
+
+    <!-- COMPONENT: yaml/code card -->
+    <div class="yaml-card">
+      <div class="yaml-head"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="yaml-file">{{FILENAME}}</span></div>
+      <div class="yaml-body"><span class="l"><span class="c"># {{COMMENT}}</span></span><span class="l"><span class="k">{{KEY}}</span> <span class="s">{{STRING}}</span></span><span class="l"><span class="d">value:</span> <span class="n">{{NUMBER}}</span></span></div>
+    </div>
+  </div>
+</section>
+
+<section class="chapter chapter-flip" id="c2">
+  <div class="chapter-inner reveal">
+    <div class="chapter-num">Chapter II</div>
+    <h2 class="chapter-h">{{CHAPTER_HEAD}} <span class="muted">{{MUTED_CLAUSE}}</span></h2>
+    <p class="chapter-p">{{BODY}}</p>
+
+    <!-- COMPONENT: ledger (numbered findings) -->
+    <div class="h-sub">{{SUBHEAD}}</div>
+    <div class="ledger">
+      <div class="ledger-row"><div class="ledger-i">①</div><div><div class="ledger-t">{{FINDING_1}}</div><div class="ledger-b">{{DETAIL_1}}</div></div></div>
+      <div class="ledger-row"><div class="ledger-i" style="color:var(--leaf)">✓</div><div><div class="ledger-t">{{FINDING_2}}</div><div class="ledger-b"><span class="tag-good">verified</span> &nbsp; {{DETAIL_2}}</div></div></div>
+    </div>
+
+    <!-- COMPONENT: note card (a verified / synced state) -->
+    <div class="note-card">
+      <div class="note-head"><span class="note-circle"></span><span class="note-title">{{NOTE_TITLE}}</span></div>
+      <div class="note-body"><b>{{K1}}</b> → {{V1}}<br><b>{{K2}}</b> → {{V2}}</div>
+      <div class="note-sync"><span class="sync-dot"></span> {{SYNC_LINE}}</div>
+    </div>
+  </div>
+</section>
+
+<!-- CALLOUT  (the ONE bombshell finding — dark card) -->
+<section class="callout reveal" style="padding-top:30px; padding-bottom:30px">
+  <div class="callout-inner grain">
+    <div class="callout-eye">{{CALLOUT_EYEBROW}}</div>
+    <div class="callout-h">{{CALLOUT_A}} <em>{{CALLOUT_ACCENT}}</em> {{CALLOUT_B}}</div>
+    <p class="callout-p">{{CALLOUT_BODY}}</p>
+  </div>
+</section>
+
+<!-- CHAPTER with decision matrix (the cheat sheet) -->
+<section class="chapter" id="c3">
+  <div class="chapter-inner reveal">
+    <div class="chapter-num">Chapter III</div>
+    <h2 class="chapter-h">{{CHAPTER_HEAD}} <span class="muted">{{MUTED_CLAUSE}}</span></h2>
+    <p class="chapter-p">{{BODY}}</p>
+    <div class="tbl-wrap">
+      <table class="tbl">
+        <thead><tr><th>{{COL1}}</th><th>{{COL2}}</th><th>{{COL3}}</th></tr></thead>
+        <tbody>
+          <tr><td>{{ROW1_A}}</td><td><div class="pick">{{ROW1_PICK}}</div></td><td><div class="why">{{ROW1_WHY}}</div></td></tr>
+          <tr><td>{{ROW2_A}}</td><td><div class="pick">{{ROW2_PICK}}</div></td><td><div class="why">{{ROW2_WHY}}</div></td></tr>
+          <tr><td>{{ROW3_A}}</td><td><div class="pick">{{ROW3_PICK}}</div></td><td><div class="why">{{ROW3_WHY}}</div></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- CLOSING -->
+<section class="closing reveal">
+  <div class="closing-mark">✦</div>
+  <h2 class="closing-h">{{CLOSING_HEAD}}</h2>
+  <p class="closing-p">{{CLOSING_BODY}}</p>
+  <div class="closing-cta">
+    <a class="btn btn-primary" href="{{SOURCE_URL}}" target="_blank" rel="noopener">{{CLOSE_CTA}} ↗</a>
+    <a class="btn btn-ghost" href="#c1">Back to the top ↑</a>
+  </div>
+</section>
+
+<!-- FOOTER + SOURCES -->
+<footer>
+  <div class="foot-inner">
+    <div class="foot-gift">{{GIFT_A}} <em>{{GIFT_ACCENT}}</em> {{GIFT_B}}</div>
+    <div class="foot-meta">{{META_1}}<br>{{META_2}}<br>Applaudé editorial language</div>
+  </div>
+  <div class="sources">
+    <div class="sources-h">Sources</div>
+    <a href="{{SRC_URL_1}}" target="_blank" rel="noopener">{{SRC_LABEL_1}}</a>
+    <a href="{{SRC_URL_2}}" target="_blank" rel="noopener">{{SRC_LABEL_2}}</a>
+  </div>
+</footer>
+
+<script>
+// reveal-on-scroll
+const io = new IntersectionObserver((entries)=>{
+  entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in'); io.unobserve(e.target); } });
+}, { threshold: 0.08 });
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+
+// nav active on scroll
+const links = [...document.querySelectorAll('.nav-links a')];
+const sections = links.map(a=>document.querySelector(a.getAttribute('href'))).filter(Boolean);
+const navIo = new IntersectionObserver((entries)=>{
+  entries.forEach(e=>{
+    if(e.isIntersecting){
+      links.forEach(l=>l.style.background='');
+      const active = links.find(l=>l.getAttribute('href')==='#'+e.target.id);
+      if(active) active.style.background='rgba(31,30,29,0.06)';
+    }
+  });
+}, { rootMargin:'-45% 0px -50% 0px' });
+sections.forEach(s=>navIo.observe(s));
+</script>
+</body>
+</html>

--- a/.agents/skills/ApplaudeExplainer/SKILL.md
+++ b/.agents/skills/ApplaudeExplainer/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: applaude-explainer
+description: Build a beautiful, source-cited, single-file HTML explainer on any topic in the Applaudé editorial design language — warm pampas canvas, clay-italic accents, Fraunces serif + Geist, hairline dividers, flow diagrams, stat strips, mac-window YAML/code cards, sage "verified" note cards, and a dark "bombshell" callout — then save it to ~/Desktop/Explainers and open it. Two modes — DEFAULT (#exap, any topic) and REPO/16W (#16w, drop a GitHub repo and it honestly answers the 10 questions of the 16-word sales-letter framework — what is this, is it good, how is it different — with zero hype, plus an optional 10-part video script pack). Same research rigor as a topic explainer (named numbers, verbatim <code> IDs, decision matrix, sources block) in the "Apple × Claude" Applaudé look. USE WHEN the message contains #exap or #16w, or says — applaude explainer, exap this, exap X, make an applaude explainer of X, explain X in the applaude style, explain this github repo, is this repo any good, drop in a repo and explain it, 16 word, ten questions explainer, do an applaude deep-dive on X. NOT FOR the dark editorial topic-explainer theme (use topic-explainer) or one-paragraph summaries.
+---
+
+# Applaudé Explainer
+
+Turn any topic into an editorial-grade, source-cited, single-file HTML explainer in the **Applaudé** design language — *"Apple × Claude editorial."* Warm pampas paper, warm-ink type, clay-italic accents, hairlines instead of borders, big breathing whitespace.
+
+Trigger: **`#exap`** (anywhere in the message), or any close variant ("make an applaude explainer of X", "exap the X keynote", "explain X in the applaude style").
+
+## Two modes
+
+- **Default — `#exap` / any topic.** Free-form explainer. Chapters follow the topic's own structure. Process below.
+- **Repo / 16W — `#16w` + a GitHub URL.** Drop in a repo; the page *answers* the 10 questions of the 16-word sales-letter framework (what is this · is it good · how is it different · why trust it · how to start · what to lose…) **honestly, no hype, question never stated.** Can also emit a 10-part video script pack (one per question). Full intake steps, the 10-answer → component map, the no-sales rules, and the video spec are in **`References/sixteen-word.md`** — read it when `#16w` fires. Everything below (design system, template, voice) still applies; only the chapter scaffold changes to the 10 answers.
+
+## What it produces
+
+- **One self-contained `.html` file.** No build step, no framework. Only Google Fonts (Fraunces + Geist + Geist Mono) over CDN.
+- **Saved to `$HOME/Desktop/Explainers/{topic-slug}-explainer.html`** — always. Then opened with `open`.
+- Light, warm, editorial. The opposite of the dark `topic-explainer` theme. Same content rigor, different skin.
+
+## Three-stage process
+
+### Stage A — Research (spend the first half here)
+Use web search + fetch. Launch 2–4 parallel research probes via the Agent tool for broad topics.
+1. **Hit primary sources** — official docs, GitHub READMEs, blog posts, papers, press releases. Capture before summarizing.
+2. **Quote IDs verbatim** — model names, repo paths, SKUs, version numbers, env vars. Never paraphrase identifiers; wrap each in `<code>`.
+3. **Capture exact numbers** — counts, scores, dollars, percentages, latencies. These become the stat strip and decision table.
+4. **Find the under-the-radar story** — the buried detail. It becomes the dark "bombshell" callout.
+5. **Flag what you can't confirm** — write "could not verify," never confabulate.
+6. **Keep every URL** — they go in the bottom sources block.
+
+If the topic is something just produced in this session (research, a teardown, a build), use that first-hand verified material directly — it's the strongest source you have.
+
+### Stage B — Build from the template
+1. Copy `References/template.html` as the scaffold. **Keep the entire `<style>` block unchanged** — it *is* the Applaudé design system. Only swap content in the `<body>`.
+2. Fill the components in order: nav → hero (eyebrow pill + serif h1 with one clay-italic accent word + 3-sentence lede + CTA pair) → 4-up stat strip → 4–7 chapters → dark callout → decision matrix → closing → footer + sources.
+3. Map content to the right component (see `References/design-system.md`):
+   - **Flow grid** → any sequence/loop/pipeline (3–4 steps + arrows).
+   - **YAML/code card** → commands, config, code (mac traffic-lights + token coloring).
+   - **Stat strip** → the 4 headline numbers (2nd & 3rd render italic clay).
+   - **Note card** → a verified/synced state (sage dot = good).
+   - **Dark callout** → the one bombshell finding.
+   - **Decision matrix** → the "if you want X, do Y" cheat sheet readers crave.
+4. Alternate `.chapter` and `.chapter chapter-flip` (pampas-deep) backgrounds for rhythm.
+
+### Stage C — Save, verify, open
+1. Save to `$HOME/Desktop/Explainers/{topic-slug}-explainer.html`.
+2. **Verify in a real browser** before claiming done — open the file and screenshot the hero + 2–3 interior sections; confirm Applaudé styling rendered (pampas bg, Fraunces hero, clay italic, hairlines). Use the Interceptor skill if installed; otherwise fall back to the session's Chrome tooling (`chrome-devtools-axi open <file://…>` + `screenshot`). Delete temp screenshots after.
+3. `open "$HOME/Desktop/Explainers/{slug}-explainer.html"`.
+
+## Quick design tokens (full set in References/design-system.md)
+
+- **Canvas** `--pampas #F0EEE6` · **ink** `#1F1E1D` · **clay accent** `--crail #C96442` · **sage** `--leaf #8B9D7E` (good/synced) · **sky** `--sky #6B8AA8` (numbers).
+- **Type** — display/body serif `Fraunces` (Tiempos if licensed), UI/sans `Geist`, mono `Geist Mono`.
+- **Voice rules** — `em` = clay italic (human voice). Mono = system speaking. Hairlines (`0.5px @ 8–18% ink`), never solid borders. Clay is a verb, not a fill — it punctuates, never floods. Big editorial whitespace (120–140px chapter padding). Centered columns 640–880px.
+
+## Content rules (full set in References/content-patterns.md)
+
+- **Hero lede** = three sentences: the lazy story → the *real* story (italic pivot word) → the call to read.
+- **Named numbers** — ≥4 specific, source-cited numbers per chapter. "jumped AIME 20.8% → 89.2%", not "dramatically improves".
+- **Verbatim IDs** — every model/SKU/repo/env-var in `<code>`.
+- **Tone** — confident, editorial, specific, short. Italic for tone, bold for facts. Cut every sentence in half until it stops cutting.
+
+## Reference files
+
+- **`References/template.html`** — the proven scaffold. Full Applaudé CSS + a one-of-each component skeleton with `{{PLACEHOLDER}}` markers. Copy and refill.
+- **`References/design-system.md`** — palette meaning, type scale, every component (nav, hero, stats, chapters, flow grid, YAML card, note card, callout, decision matrix, closing, footer), motion, responsive rules.
+- **`References/content-patterns.md`** — hero-lede formula, big-card formula, named-numbers rule, verbatim-ID rule, tone.
+
+## Quality checklist
+
+- [ ] Saved to `$HOME/Desktop/Explainers/{slug}-explainer.html` and opened.
+- [ ] Pampas canvas, warm ink, Fraunces serif hero with exactly one clay-italic accent word.
+- [ ] Hairlines everywhere — no solid 1px borders.
+- [ ] Clay used only as accent (italic words, links, live dot, one callout) — never as a fill background except the single dark callout.
+- [ ] 4-up stat strip; 2nd & 3rd numbers italic clay.
+- [ ] ≥4 named, source-cited numbers per chapter; every ID in `<code>`.
+- [ ] One dark "bombshell" callout for the buried finding.
+- [ ] Decision matrix present.
+- [ ] Sources block at the foot with every URL.
+- [ ] Single self-contained `.html`; verified rendered in a browser.


### PR DESCRIPTION
Adds the ApplaudeExplainer agent skill to the repository.

**What it does:**
- Generates beautiful, source-cited, single-file HTML explainers in the Applaudé editorial design language
- Warm pampas canvas, Fraunces serif + Geist type, clay-italic accents, hairline dividers
- Two modes:
  - `#exap` — free-form explainer on any topic
  - `#16w` — honest GitHub repo deep-dive using the 16-word sales-letter framework
- Self-contained HTML output saved to `~/Desktop/Explainers`

**Files added:**
- `.agents/skills/ApplaudeExplainer/SKILL.md`
- `.agents/skills/ApplaudeExplainer/References/template.html`
- `.agents/skills/ApplaudeExplainer/References/design-system.md`
- `.agents/skills/ApplaudeExplainer/References/content-patterns.md`
- `.agents/skills/ApplaudeExplainer/References/sixteen-word.md`